### PR TITLE
90 fix multiple declare issue for displaytext

### DIFF
--- a/assets/batteryDisplay.js
+++ b/assets/batteryDisplay.js
@@ -33,11 +33,11 @@ function getTimeUnits(time) {
 
 function updateTime(totalHours, totalMinutes, totalSeconds) {
   if (totalHours !== 0) {
-    displayText.textContent = `${totalHours} hours`;
+    displayTextEl.textContent = `${totalHours} hours`;
   } else if (totalMinutes !== 0) {
-    displayText.textContent = `${totalMinutes} minutes`;
+    displayTextEl.textContent = `${totalMinutes} minutes`;
   } else {
-    displayText.textContent = `${totalSeconds} seconds`;
+    displayTextEl.textContent = `${totalSeconds} seconds`;
   }
 }
 


### PR DESCRIPTION
There was a syntax error stating the variable displayText was being declared more than once.

I adjusted the variable displayText on batteryDisplay.js to be displayTextEl.

I adjusted the rest of the file to reflect the changes made to the variable.

I confirmed that the syntax error was cleared.